### PR TITLE
Minor CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Go Mod Tidy
+          command: go mod tidy
+      - run:
           name: Check Module Tidiness
-          command: |-
-            go mod tidy
-            git diff --exit-code -- go.mod go.sum
+          command: git diff --exit-code -- go.mod go.sum
 
   build_source:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - checkout
       - run:
           name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.28.1
       - run:
           name: Check for Lint
           command: golangci-lint run


### PR DESCRIPTION
Split `check_mod_tidy` into two steps to separate useful output from noise. Bump `golangci-lint` to 1.28.1.