### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.14
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.28.1-alpine
+      - image: golangci/golangci-lint:v1.29-alpine
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ executors:
   golang:
     docker:
       - image: golang:1.14
+  golangci-lint:
+    docker:
+      - image: golangci/golangci-lint:v1.28.1-alpine
 
 jobs:
   lint_markdown:
@@ -43,12 +46,9 @@ jobs:
           command: go build ./...
 
   lint_source:
-    executor: golang
+    executor: golangci-lint
     steps:
       - checkout
-      - run:
-          name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.28.1
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.1.0
+  codecov: codecov/codecov@1.1
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,17 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.1
 
-jobs:
-  lint_markdown:
+executors:
+  node:
     docker:
       - image: node:14-slim
+  golang:
+    docker:
+      - image: golang:1.14
+
+jobs:
+  lint_markdown:
+    executor: node
     steps:
       - checkout
       - run:
@@ -17,8 +24,7 @@ jobs:
           command: markdownlint .
 
   check_mod_tidy:
-    docker:
-      - image: golang:1.14
+    executor: golang
     steps:
       - checkout
       - run:
@@ -29,8 +35,7 @@ jobs:
           command: git diff --exit-code -- go.mod go.sum
 
   build_source:
-    docker:
-      - image: golang:1.14
+    executor: golang
     steps:
       - checkout
       - run:
@@ -38,8 +43,7 @@ jobs:
           command: go build ./...
 
   lint_source:
-    docker:
-      - image: golang:1.14
+    executor: golang
     steps:
       - checkout
       - run:
@@ -50,8 +54,7 @@ jobs:
           command: golangci-lint run
 
   unit_test:
-    docker:
-      - image: golang:1.14
+    executor: golang
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Implement reusable executors. Use latest Codecov Orb, and update `golangci-lint` to v1.29.