### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.16
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.30-alpine
+      - image: golangci/golangci-lint:v1.39-alpine
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:14-slim
+      - image: node:15-slim
   golang:
     docker:
       - image: golang:1.15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:15-slim
   golang:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.30-alpine

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - prealloc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/scs-build-client
 
-go 1.14
+go 1.15
 
 require (
 	github.com/go-log/log v0.2.0


### PR DESCRIPTION
Bump `node` to 15.x, `golang` to 1.16, and `golangci-lint` to 1.39. Remove deprecated `interfacer` and `maligned` linters.