### PR TITLE
Bump Go to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.41-alpine
   golang-previous:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golang-latest:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
 
 jobs:
   lint-markdown:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -148,7 +148,7 @@ func TestNewRequest(t *testing.T) {
 					t.Errorf("got URL %v, want %v", got, want)
 				}
 
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Errorf("failed to read body: %v", err)
 				}

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -8,7 +8,6 @@ package client_test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -152,7 +151,7 @@ func TestBuild(t *testing.T) {
 	defer cancel()
 
 	// Create a temporary file for testing
-	f, err := ioutil.TempFile("/tmp", "TestBuild")
+	f, err := os.CreateTemp("/tmp", "TestBuild")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/scs-build-client
 
-go 1.15
+go 1.17
 
 require (
 	github.com/go-log/log v0.2.0


### PR DESCRIPTION
Bump `go.mod` language version to 1.17 to take advantage of [lazy loading](https://golang.org/ref/mod#lazy-loading). Bump CI Go version range to 1.16-1.17. Remove use of deprecated `ioutil` package.