### PR TITLE
ci: bump golangci-lint to 1.43

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:16-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.42-alpine
+      - image: golangci/golangci-lint:v1.43-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,9 @@
 linters:
   disable-all: true
   enable:
+    - bidichk
     - bodyclose
+    - contextcheck
     - deadcode
     - depguard
     - dogsled
@@ -17,14 +19,17 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - ireturn
     - misspell
     - nakedret
+    - nilnil
     - prealloc
     - revive
     - rowserrcheck
     - staticcheck
     - structcheck
     - stylecheck
+    - tenv
     - typecheck
     - unconvert
     - unparam


### PR DESCRIPTION
Bump `golangci-lint` to v1.43. Enable `bidichk`, `contextcheck`, `ireturn`, `nilnil`, and `tenv` linters.