### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.43-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.43-alpine
+      - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,15 @@ linters:
   enable:
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
     - errcheck
+    - errchkjson
     - gochecknoinits
     - goconst
     - gocyclo
@@ -18,8 +21,10 @@ linters:
     - goprintffuncname
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - ireturn
+    - maintidx
     - misspell
     - nakedret
     - nilnil

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
 # LICENSE
 
+Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -27,7 +27,7 @@ func TestSubmit(t *testing.T) {
 		expectSuccess bool
 		libraryRef    string
 		responseCode  int
-		ctx           context.Context
+		ctx           context.Context //nolint:containedctx
 	}{
 		{"SuccessAttached", true, "", http.StatusCreated, context.Background()},
 		{"SuccessLibraryRef", true, "library://user/collection/image", http.StatusCreated, context.Background()},

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -188,7 +188,7 @@ func TestBuild(t *testing.T) {
 		wsCloseCode         int
 		statusResponseCode  int
 		imageResponseCode   int
-		ctx                 context.Context
+		ctx                 context.Context //nolint:containedctx
 	}{
 		{"Success", true, true, true, f.Name(), "", http.StatusCreated, http.StatusOK, websocket.CloseNormalClosure, http.StatusOK, http.StatusOK, context.Background()},
 		{"SuccessLibraryRef", true, true, true, "library://user/collection/image", "", http.StatusCreated, http.StatusOK, websocket.CloseNormalClosure, http.StatusOK, http.StatusOK, context.Background()},

--- a/client/output_test.go
+++ b/client/output_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -50,7 +50,7 @@ func TestOutput(t *testing.T) {
 		expectSuccess   bool
 		wsResponseCode  int
 		wsCloseCode     int
-		ctx             context.Context
+		ctx             context.Context //nolint:containedctx
 		outputReadFully bool
 		outputReadErr   error
 	}{

--- a/client/status_test.go
+++ b/client/status_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -26,7 +26,7 @@ func TestStatus(t *testing.T) {
 		description   string
 		expectSuccess bool
 		responseCode  int
-		ctx           context.Context
+		ctx           context.Context //nolint:containedctx
 	}{
 		{"Success", true, http.StatusOK, context.Background()},
 		{"NotFound", false, http.StatusNotFound, context.Background()},


### PR DESCRIPTION
Bump `node` to v17, and `golangci-lint` to v1.44.