### PR TITLE
Publish Binary on Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,14 @@ jobs:
       - codecov/upload:
           file: cover.out
 
+  release-test:
+    executor: golang-latest
+    steps:
+      - checkout
+      - run:
+          name: Test Release
+          command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
+
 workflows:
   version: 2
 
@@ -88,3 +96,4 @@ workflows:
           matrix:
             parameters:
               e: ["golang-previous", "golang-latest"]
+      - release-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,14 @@ jobs:
           name: Test Release
           command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
 
+  publish-release:
+    executor: golang-latest
+    steps:
+      - checkout
+      - run:
+          name: Publish Release
+          command: curl -sL https://git.io/goreleaser | bash
+
 workflows:
   version: 2
 
@@ -97,3 +105,13 @@ workflows:
             parameters:
               e: ["golang-previous", "golang-latest"]
       - release-test
+
+  tagged-release:
+    jobs:
+      - publish-release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+          context: github-release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+project_name: scs-build-client
+
+release:
+  github:
+    owner: sylabs
+    name: scs-build-client
+  prerelease: auto
+
+builds:
+  - id: scs-build
+    main: ./cmd/scs-build
+    binary: scs-build
+    flags: '-trimpath'
+    ldflags: '-s -w -X main.version={{ .Version }} -X main.commit={{ .FullCommit }} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser'
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - '6'
+      - '7'
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+archives:
+  - format: tar.gz
+    wrap_in_directory: 'true'
+    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    files:
+      - LICENSE.md
+      - README.md
+
+checksum:
+  name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^dev:'
+      - '^docs:'
+      - '^test:'
+      - '^Merge branch'
+      - '^Merge pull request'

--- a/cmd/scs-build/main.go
+++ b/cmd/scs-build/main.go
@@ -12,10 +12,16 @@ import (
 	"github.com/sylabs/scs-build-client/cmd/scs-build/cmd"
 )
 
-var version = ""
+var (
+	version = "unknown"
+	date    = ""
+	builtBy = ""
+	commit  = ""
+	state   = ""
+)
 
 func main() {
-	if err := cmd.Execute(version); err != nil {
+	if err := cmd.Execute(version, date, builtBy, commit, state); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Add `release-test` and `publish-release` jobs and `tagged-release` workflow in CI config. Add `goreleaser` configuration.

Extend `version` command to output build metadata:

```
$ ./scs-build_linux_amd64/scs-build version
Version:  0.2.1-SNAPSHOT-68e1d0b
By:       goreleaser
Commit:   68e1d0b95a799854fb5340facda1c7a3ec9a0ce8
Date:     2022-03-01T19:17:33Z
Runtime:  go1.17.7 (linux/amd64)
```

Closes #67 