### PR TITLE
Goreleaser Improvements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,48 +1,71 @@
-project_name: scs-build-client
-
 release:
-  github:
-    owner: sylabs
-    name: scs-build-client
   prerelease: auto
 
+changelog:
+  use: github-native
+
+gomod:
+  proxy: true
+  env:
+    - GOPROXY=https://proxy.golang.org,direct
+    - GOSUMDB=sum.golang.org
+
 builds:
-  - id: scs-build
-    main: ./cmd/scs-build
+  - id: darwin-builds
     binary: scs-build
-    flags: '-trimpath'
-    ldflags: '-s -w -X main.version={{ .Version }} -X main.commit={{ .FullCommit }} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser'
-    env:
-      - CGO_ENABLED=0
     goos:
       - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: &build-main ./cmd/scs-build
+    mod_timestamp: &build-timestamp '{{ .CommitTimestamp }}'
+    env: &build-env
+      - CGO_ENABLED=0
+    flags: &build-flags '-trimpath'
+    ldflags: &build-ldflags |
+      -s
+      -w
+      -X main.version={{ .Version }}
+      -X main.date={{ .CommitDate }}
+      -X main.builtBy=goreleaser
+      -X main.commit={{ .FullCommit }}
+
+  - id: linux-builds
+    binary: scs-build
+    goos:
       - linux
     goarch:
       - amd64
-      - arm
       - arm64
-    goarm:
-      - '6'
-      - '7'
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    main: *build-main
+    mod_timestamp: *build-timestamp
+    env: *build-env
+    flags: *build-flags
+    ldflags: *build-ldflags
+
+  - id: windows-builds
+    binary: scs-build
+    goos:
+      - windows
+    goarch:
+      - amd64
+    main: *build-main
+    mod_timestamp: *build-timestamp
+    env: *build-env
+    flags: *build-flags
+    ldflags: *build-ldflags
 
 archives:
-  - format: tar.gz
-    wrap_in_directory: 'true'
-    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    files:
-      - LICENSE.md
-      - README.md
+  - id: darwin-archives
+    builds:
+      - darwin-builds
 
-checksum:
-  name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'
+  - id: linux-archives
+    builds:
+      - linux-builds
 
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^dev:'
-      - '^docs:'
-      - '^test:'
-      - '^Merge branch'
-      - '^Merge pull request'
+  - id: windows-archives
+    format: zip
+    builds:
+      - windows-builds

--- a/cmd/scs-build/build.go
+++ b/cmd/scs-build/build.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package cmd
+package main
 
 import (
 	"context"

--- a/cmd/scs-build/main.go
+++ b/cmd/scs-build/main.go
@@ -8,20 +8,10 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/sylabs/scs-build-client/cmd/scs-build/cmd"
-)
-
-var (
-	version = "unknown"
-	date    = ""
-	builtBy = ""
-	commit  = ""
-	state   = ""
 )
 
 func main() {
-	if err := cmd.Execute(version, date, builtBy, commit, state); err != nil {
+	if err := execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/scs-build/root.go
+++ b/cmd/scs-build/root.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package cmd
+package main
 
 import (
 	"fmt"
@@ -19,7 +19,15 @@ var rootCmd = &cobra.Command{
 	Short: "Sylabs Cloud Build Client",
 }
 
-func writeVersion(w io.Writer, version, date, builtBy, commit, state string) {
+// Build metadata set by linker.
+var (
+	version = "unknown"
+	date    = ""
+	builtBy = ""
+	commit  = ""
+)
+
+func writeVersion(w io.Writer) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	defer tw.Flush()
 
@@ -30,11 +38,7 @@ func writeVersion(w io.Writer, version, date, builtBy, commit, state string) {
 	}
 
 	if commit != "" {
-		if state == "" {
-			fmt.Fprintf(tw, "Commit:\t%v\n", commit)
-		} else {
-			fmt.Fprintf(tw, "Commit:\t%v (%v)\n", commit, state)
-		}
+		fmt.Fprintf(tw, "Commit:\t%v\n", commit)
 	}
 
 	if date != "" {
@@ -44,7 +48,7 @@ func writeVersion(w io.Writer, version, date, builtBy, commit, state string) {
 	fmt.Fprintf(tw, "Runtime:\t%v (%v/%v)\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }
 
-func Execute(version, date, builtBy, commit, state string) error {
+func execute() error {
 	// Add version subcommand
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
@@ -52,7 +56,7 @@ func Execute(version, date, builtBy, commit, state string) error {
 		Long:  "Display binary version, and build info.",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			writeVersion(cmd.OutOrStdout(), version, date, builtBy, commit, state)
+			writeVersion(cmd.OutOrStdout())
 		},
 	})
 


### PR DESCRIPTION
Simplify `goreleaser` configuration by using default values and anchors as appropriate. Add `windows`/`amd64` build. Switch to `github-native` changelog generation. Add `gomod` configuration for reproducible build. Remove `state` variable from `main` package, since it is not set by `goreleaser`. Collapse Cobra code into `main` package, so it can directly access build metadata set by `goreleaser`.