### PR TITLE
Build OCI Images in Release Automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,11 @@ jobs:
     executor: golang-latest
     steps:
       - checkout
+      - setup_remote_docker:
+          version: &docker-version 20.10.11
+      - run:
+          name: Install Docker
+          command: curl -sL https://get.docker.com | bash
       - run:
           name: Test Release
           command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
@@ -84,6 +89,14 @@ jobs:
     executor: golang-latest
     steps:
       - checkout
+      - setup_remote_docker:
+          version: &docker-version 20.10.11
+      - run:
+          name: Install Docker
+          command: curl -sL https://get.docker.com | bash
+      - run:
+          name: Authenticate with DockerHub
+          command: echo "${DOCKER_PASSWORD}" | docker login docker.io -u "${DOCKER_USERNAME}" --password-stdin
       - run:
           name: Publish Release
           command: curl -sL https://git.io/goreleaser | bash
@@ -114,4 +127,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-          context: github-release
+          context:
+            - dockerhub-release
+            - github-release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,3 +69,12 @@ archives:
     format: zip
     builds:
       - windows-builds
+
+dockers:
+  - image_templates:
+      - sylabsio/scs-build:latest
+      - sylabsio/scs-build:{{ .Major }}-amd64
+      - sylabsio/scs-build:{{ .Major }}.{{ .Minor }}-amd64
+      - sylabsio/scs-build:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64
+    skip_push: auto
+    dockerfile: ./build/docker/scs-build/Dockerfile

--- a/build/docker/scs-build/Dockerfile
+++ b/build/docker/scs-build/Dockerfile
@@ -3,18 +3,13 @@
 # LICENSE.md file distributed with the sources of this project regarding your
 # rights to use or distribute this software.
 
-ARG GOLANG_TAG=1.17-alpine
+FROM alpine:latest AS build-stage
+RUN apk --no-cache add ca-certificates
 
-FROM golang:$GOLANG_TAG as build-stage
-RUN apk add --no-cache git ca-certificates && update-ca-certificates
-WORKDIR /src
-COPY . .
-RUN CGO_ENABLED=0 go install -mod=vendor -ldflags "-X main.version=`git describe --long --dirty --always`" ./cmd/scs-build/
-
-FROM alpine:latest
-COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build-stage /go/bin/scs-build /usr/local/bin/
+FROM scratch
+COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY scs-build /
 
 USER 1000
 
-ENTRYPOINT ["/usr/local/bin/scs-build"]
+ENTRYPOINT ["/scs-build"]


### PR DESCRIPTION
Add AMD64 Docker image build in `goreleaser` config. Expose Docker in `release-test` and `publish-release` CI jobs.

Closes #68 