### PR TITLE
Improve HTTP Status Code Handling

### DIFF
--- a/client/build.go
+++ b/client/build.go
@@ -15,46 +15,54 @@ import (
 	jsonresp "github.com/sylabs/json-resp"
 )
 
-// Submit sends a build job to the Build Service. The context controls the
-// lifetime of the request.
-func (c *Client) Submit(ctx context.Context, br BuildRequest) (bi BuildInfo, err error) {
+// Submit sends a build job to the Build Service. The context controls the lifetime of the request.
+func (c *Client) Submit(ctx context.Context, br BuildRequest) (BuildInfo, error) {
 	b, err := json.Marshal(br)
 	if err != nil {
-		return
+		return BuildInfo{}, fmt.Errorf("%w", err)
 	}
 
 	req, err := c.newRequest(http.MethodPost, "/v1/build", bytes.NewReader(b))
 	if err != nil {
-		return
+		return BuildInfo{}, fmt.Errorf("%w", err)
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return
+		return BuildInfo{}, fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
-	err = jsonresp.ReadResponse(res.Body, &bi)
-	return bi, err
+	if res.StatusCode/100 != 2 { // non-2xx status code
+		return BuildInfo{}, fmt.Errorf("%w", errorFromResponse(res))
+	}
+
+	var bi BuildInfo
+	if err = jsonresp.ReadResponse(res.Body, &bi); err != nil {
+		return BuildInfo{}, fmt.Errorf("%w", err)
+	}
+
+	return bi, nil
 }
 
-// Cancel cancels an existing build. The context controls the lifetime of the
-// request.
+// Cancel cancels an existing build. The context controls the lifetime of the request.
 func (c *Client) Cancel(ctx context.Context, buildID string) error {
 	req, err := c.newRequest(http.MethodPut, fmt.Sprintf("/v1/build/%s/_cancel", buildID), nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w", err)
 	}
 
 	res, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
-		return err
+		return fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("build cancellation failed: http status %d", res.StatusCode)
+
+	if res.StatusCode/100 != 2 { // non-2xx status code
+		return fmt.Errorf("%w", errorFromResponse(res))
 	}
+
 	return nil
 }

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package client_test
+package client
 
 import (
 	"context"
@@ -12,8 +12,6 @@ import (
 	"net/url"
 	"testing"
 	"time"
-
-	"github.com/sylabs/scs-build-client/client"
 )
 
 func TestSubmit(t *testing.T) {
@@ -45,7 +43,7 @@ func TestSubmit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
 	}
-	c, err := client.New(&client.Config{
+	c, err := New(&Config{
 		BaseURL: url.String(),
 	})
 	if err != nil {
@@ -58,7 +56,7 @@ func TestSubmit(t *testing.T) {
 			m.buildResponseCode = tt.responseCode
 
 			// Call the handler
-			bi, err := c.Submit(tt.ctx, client.BuildRequest{
+			bi, err := c.Submit(tt.ctx, BuildRequest{
 				DefinitionRaw: []byte{},
 				LibraryRef:    tt.libraryRef,
 				LibraryURL:    "",
@@ -99,7 +97,7 @@ func TestCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
 	}
-	c, err := client.New(&client.Config{
+	c, err := New(&Config{
 		BaseURL: url.String(),
 	})
 	if err != nil {

--- a/client/error.go
+++ b/client/error.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
+// distributed with the sources of this project regarding your rights to use or distribute this
+// software.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	jsonresp "github.com/sylabs/json-resp"
+)
+
+// httpError represents an error returned from an HTTP server.
+type httpError struct {
+	Code int
+	err  error
+}
+
+// Unwrap returns the error wrapped by e.
+func (e *httpError) Unwrap() error { return e.err }
+
+// Error returns a human-readable representation of e.
+func (e *httpError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%v %v: %v", e.Code, http.StatusText(e.Code), e.err.Error())
+	}
+	return fmt.Sprintf("%v %v", e.Code, http.StatusText(e.Code))
+}
+
+// Is compares e against target. If target is a HTTPError with the same code as e, true is returned.
+func (e *httpError) Is(target error) bool {
+	t, ok := target.(*httpError)
+	return ok && (t.Code == e.Code)
+}
+
+// errorFromResponse returns an HTTPError containing the status code and detailed error message (if
+// available) from res.
+func errorFromResponse(res *http.Response) error {
+	httpErr := httpError{Code: res.StatusCode}
+
+	var jerr *jsonresp.Error
+	if err := jsonresp.ReadError(res.Body); errors.As(err, &jerr) {
+		httpErr.err = errors.New(jerr.Message)
+	}
+
+	return &httpErr
+}

--- a/client/error_test.go
+++ b/client/error_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
+// distributed with the sources of this project regarding your rights to use or distribute this
+// software.
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        int
+		err         error
+		wantMessage string
+	}{
+		{
+			name:        "BadRequest",
+			code:        http.StatusBadRequest,
+			wantMessage: "400 Bad Request",
+		},
+		{
+			name:        "BadRequestWithMessage",
+			code:        http.StatusBadRequest,
+			err:         errors.New("more good needed"),
+			wantMessage: "400 Bad Request: more good needed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &httpError{
+				Code: tt.code,
+				err:  tt.err,
+			}
+
+			if got, want := err.Code, tt.code; got != want {
+				t.Errorf("got code %v, want %v", got, want)
+			}
+			if got, want := err.Unwrap(), tt.err; got != want {
+				t.Errorf("got unwrapped error %v, want %v", got, want)
+			}
+			if got, want := err.Error(), tt.wantMessage; got != want {
+				t.Errorf("got message %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package client_test
+package client
 
 import (
 	"context"
@@ -18,7 +18,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	jsonresp "github.com/sylabs/json-resp"
-	"github.com/sylabs/scs-build-client/client"
 )
 
 type mockService struct {
@@ -48,7 +47,7 @@ const (
 	buildCancelSuffix = "/_cancel"
 )
 
-func newResponse(m *mockService, id string, def []byte, libraryRef string) client.BuildInfo {
+func newResponse(m *mockService, id string, def []byte, libraryRef string) BuildInfo {
 	libraryURL := url.URL{
 		Scheme: "http",
 		Host:   m.httpAddr,
@@ -57,7 +56,7 @@ func newResponse(m *mockService, id string, def []byte, libraryRef string) clien
 		libraryRef = "library://user/collection/image"
 	}
 
-	return client.BuildInfo{
+	return BuildInfo{
 		ID:            id,
 		DefinitionRaw: def,
 		LibraryURL:    libraryURL.String(),
@@ -71,7 +70,7 @@ func (m *mockService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Set the response body, depending on the type of operation
 	if r.Method == http.MethodPost && r.RequestURI == buildPath {
 		// Mock new build endpoint
-		var br client.BuildRequest
+		var br BuildRequest
 		if err := json.NewDecoder(r.Body).Decode(&br); err != nil {
 			m.t.Fatalf("failed to parse request: %v", err)
 		}
@@ -203,7 +202,7 @@ func TestBuild(t *testing.T) {
 	// Loop over test cases
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			c, err := client.New(&client.Config{
+			c, err := New(&Config{
 				BaseURL:   url.String(),
 				AuthToken: authToken,
 			})
@@ -219,7 +218,7 @@ func TestBuild(t *testing.T) {
 			m.imageResponseCode = tt.imageResponseCode
 
 			// Do it!
-			bd, err := c.Submit(tt.ctx, client.BuildRequest{
+			bd, err := c.Submit(tt.ctx, BuildRequest{
 				DefinitionRaw: []byte{},
 				LibraryRef:    tt.imagePath,
 				LibraryURL:    url.String(),

--- a/client/object_id_test.go
+++ b/client/object_id_test.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package client_test
+package client
 
 import (
 	"crypto/md5"

--- a/client/output_test.go
+++ b/client/output_test.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package client_test
+package client
 
 import (
 	"context"
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/sylabs/scs-build-client/client"
 )
 
 type testOutputWriter struct {
@@ -74,7 +73,7 @@ func TestOutput(t *testing.T) {
 				t.Fatalf("failed to parse URL: %v", err)
 			}
 
-			c, err := client.New(&client.Config{
+			c, err := New(&Config{
 				BaseURL:   url.String(),
 				AuthToken: authToken,
 			})

--- a/client/status.go
+++ b/client/status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,25 +7,34 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	jsonresp "github.com/sylabs/json-resp"
 )
 
 // GetStatus gets the status of a build from the Build Service by build ID
-func (c *Client) GetStatus(ctx context.Context, buildID string) (bi BuildInfo, err error) {
+func (c *Client) GetStatus(ctx context.Context, buildID string) (BuildInfo, error) {
 	req, err := c.newRequest(http.MethodGet, "/v1/build/"+buildID, nil)
 	if err != nil {
-		return
+		return BuildInfo{}, fmt.Errorf("%w", err)
 	}
 	req = req.WithContext(ctx)
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return
+		return BuildInfo{}, fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
-	err = jsonresp.ReadResponse(res.Body, &bi)
-	return
+	if res.StatusCode/100 != 2 { // non-2xx status code
+		return BuildInfo{}, fmt.Errorf("%w", errorFromResponse(res))
+	}
+
+	var bi BuildInfo
+	if err = jsonresp.ReadResponse(res.Body, &bi); err != nil {
+		return BuildInfo{}, fmt.Errorf("%w", err)
+	}
+
+	return bi, nil
 }

--- a/client/status_test.go
+++ b/client/status_test.go
@@ -3,7 +3,7 @@
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-package client_test
+package client
 
 import (
 	"context"
@@ -12,8 +12,6 @@ import (
 	"net/url"
 	"testing"
 	"time"
-
-	"github.com/sylabs/scs-build-client/client"
 )
 
 func TestStatus(t *testing.T) {
@@ -43,7 +41,7 @@ func TestStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
 	}
-	c, err := client.New(&client.Config{
+	c, err := New(&Config{
 		BaseURL: url.String(),
 	})
 	if err != nil {

--- a/client/version.go
+++ b/client/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	jsonresp "github.com/sylabs/json-resp"
@@ -19,22 +20,28 @@ type VersionInfo struct {
 	Version string `json:"version"`
 }
 
-// GetVersion gets version information from the build service. The context
-// controls the lifetime of the request.
-func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
+// GetVersion gets version information from the build service. The context controls the lifetime of
+// the request.
+func (c *Client) GetVersion(ctx context.Context) (VersionInfo, error) {
 	req, err := c.newRequest(http.MethodGet, pathVersion, nil)
 	if err != nil {
-		return VersionInfo{}, err
+		return VersionInfo{}, fmt.Errorf("%w", err)
 	}
 
 	res, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
-		return VersionInfo{}, err
+		return VersionInfo{}, fmt.Errorf("%w", err)
 	}
 	defer res.Body.Close()
 
-	if err := jsonresp.ReadResponse(res.Body, &vi); err != nil {
-		return VersionInfo{}, err
+	if res.StatusCode/100 != 2 { // non-2xx status code
+		return VersionInfo{}, fmt.Errorf("%w", errorFromResponse(res))
 	}
+
+	var vi VersionInfo
+	if err := jsonresp.ReadResponse(res.Body, &vi); err != nil {
+		return VersionInfo{}, fmt.Errorf("%w", err)
+	}
+
 	return vi, nil
 }


### PR DESCRIPTION
Add `errorFromResponse`, and use to handle all non-2xx status codes. Replace naked returns with wrapped errors. Improve unit testing.

Closes #79 