### PR TITLE
Add user-agent to library and build-clients

### DIFF
--- a/cmd/scs-build/build.go
+++ b/cmd/scs-build/build.go
@@ -98,6 +98,7 @@ func executeBuildCmd(cmd *cobra.Command, args []string) error {
 		LibraryRef:    libraryRef,
 		SkipTLSVerify: v.GetBool(keySkipTLSVerify),
 		Force:         v.GetBool(keyForceOverwrite),
+		UserAgent:     fmt.Sprintf("scs-build/%v", version),
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Application init error: %v\n", err)

--- a/internal/app/buildclient/client.go
+++ b/internal/app/buildclient/client.go
@@ -29,6 +29,7 @@ type Config struct {
 	SkipTLSVerify bool
 	LibraryRef    string
 	Force         bool
+	UserAgent     string
 }
 
 // App represents the application instance
@@ -77,7 +78,7 @@ func New(ctx context.Context, cfg *Config) (*App, error) {
 	}
 
 	// Initialize build & library clients
-	if app.buildClient, app.libraryClient, err = getClients(ctx, cfg.SkipTLSVerify, feURL, cfg.AuthToken); err != nil {
+	if app.buildClient, app.libraryClient, err = getClients(ctx, cfg.SkipTLSVerify, feURL, cfg.AuthToken, cfg.UserAgent); err != nil {
 		return nil, fmt.Errorf("error initializing client(s): %w", err)
 	}
 	return app, nil
@@ -118,7 +119,7 @@ func getFrontendURL(r *library.Ref, urlOverride string) (string, error) {
 }
 
 // getClients returns initialized clients for remote build and cloud library
-func getClients(ctx context.Context, skipVerify bool, endpoint, authToken string) (*build.Client, *library.Client, error) {
+func getClients(ctx context.Context, skipVerify bool, endpoint, authToken, userAgent string) (*build.Client, *library.Client, error) {
 	feCfg, err := endpoints.GetFrontendConfig(ctx, skipVerify, endpoint)
 	if err != nil {
 		return nil, nil, err
@@ -132,6 +133,7 @@ func getClients(ctx context.Context, skipVerify bool, endpoint, authToken string
 		BaseURL:    feCfg.BuildAPI.URI,
 		AuthToken:  authToken,
 		HTTPClient: &http.Client{Transport: tr},
+		UserAgent:  userAgent,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("error initializing build client: %w", err)
@@ -141,6 +143,7 @@ func getClients(ctx context.Context, skipVerify bool, endpoint, authToken string
 		BaseURL:    feCfg.LibraryAPI.URI,
 		AuthToken:  authToken,
 		HTTPClient: &http.Client{Transport: tr},
+		UserAgent:  userAgent,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("error initializing library client: %w", err)


### PR DESCRIPTION
Uniquely identifies requests from `scs-build` in service logs.

Closes #85 