### PR TITLE
fix: use ParseAmbiguous to parse library ref

### DIFF
--- a/internal/app/buildclient/client_test.go
+++ b/internal/app/buildclient/client_test.go
@@ -6,42 +6,50 @@
 package buildclient
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/sylabs/scs-library-client/client"
 )
 
 func TestGetFrontendURL(t *testing.T) {
 	tests := []struct {
-		name        string
-		libraryRef  string
-		overrideURL string
-		expectedURL string
-		expectError bool
+		name           string
+		overrideURL    string
+		libraryRefHost string
+		expectedURL    string
+		expectError    bool
 	}{
-		{"LibraryRefWithoutHostNoOverride", "library:entity/collection/container", "", defaultFrontendURL, false},
-		{"LibraryRefVariationWithoutHostNoOverride", "library:///entity/collection/container", "", defaultFrontendURL, false},
-		{"LibraryRefWithHostNoOverride", "library://myhost/entity/collection/container", "", "https://myhost", false},
-		{"NoLibraryRefWithoutHostNoOverride", "", "", defaultFrontendURL, false},
-		{"LibraryRefWithoutHostWithOverride", "library:entity/collection/container", "https://myhost", "https://myhost", false},
-		{"LibraryRefWithHostAndOverride", "library://myhost/entity/collection/container", "https://notmyhost", "", true},
-		{"LocalBuildSpecWithOverride", "test.sif", "https://myhost", "https://myhost", false},
-		{"LocalBuildSpecWithoutOverride", "test.sif", "", defaultFrontendURL, false},
+		{
+			name:        "WithoutOverride",
+			expectedURL: defaultFrontendURL,
+		},
+		{
+			name:        "WithOverride",
+			overrideURL: "https://myhost",
+			expectedURL: "https://myhost",
+		},
+		{
+			name:           "HostWithoutOverride",
+			libraryRefHost: "myhost",
+			expectedURL:    "https://myhost",
+		},
+		{
+			name:           "HostWithOverride",
+			overrideURL:    "https://myhost",
+			libraryRefHost: "myhost",
+			expectedURL:    "https://myhost",
+		},
+		{
+			name:           "HostWithConflictingOverride",
+			overrideURL:    "https://myotherhost",
+			libraryRefHost: "myhost",
+			expectError:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var r *client.Ref
-
-			if tt.libraryRef != "" && strings.HasPrefix(tt.libraryRef, client.Scheme+":") {
-				var err error
-				r, err = client.Parse(tt.libraryRef)
-				assert.NoError(t, err)
-			}
-
-			result, err := getFrontendURL(r, tt.overrideURL)
+			result, err := getFrontendURL(tt.overrideURL, tt.libraryRefHost)
 			if !tt.expectError {
 				if assert.NoError(t, err) {
 					assert.Equal(t, tt.expectedURL, result)


### PR DESCRIPTION
Switch from `Parse` to `ParseAmbiguous`, for consistency with Singualrity CLI. Simplify `getFrontendURL` logic, and logic around hostname in Library refs. 