### PR TITLE
Return Non-Success Exit Code on Build Failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/sylabs/json-resp v0.8.1
 	github.com/sylabs/scs-library-client v1.3.1
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (
@@ -30,6 +29,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/internal/app/buildclient/build.go
+++ b/internal/app/buildclient/build.go
@@ -8,12 +8,16 @@ package buildclient
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
 	build "github.com/sylabs/scs-build-client/client"
 )
 
+// buildArtifact sends a build request for the specified def and arch, optionally publishing it to
+// libraryRef. Output is streamed to standard output. If the build cannot be submitted, or does not
+// succeed, an error is returned.
 func (app *App) buildArtifact(ctx context.Context, def []byte, arch string, libraryRef string) (*build.BuildInfo, error) {
 	bi, err := app.buildClient.Submit(ctx, bytes.NewReader(def),
 		build.OptBuildLibraryRef(libraryRef),
@@ -28,5 +32,12 @@ func (app *App) buildArtifact(ctx context.Context, def []byte, arch string, libr
 	if bi, err = app.buildClient.GetStatus(ctx, bi.ID()); err != nil {
 		return nil, fmt.Errorf("error getting remote build status: %w", err)
 	}
+
+	// The returned info doesn't indicate an exit code, but a zero-sized image tells us something
+	// went wrong.
+	if bi.ImageSize() <= 0 {
+		return bi, errors.New("failed to build image")
+	}
+
 	return bi, nil
 }

--- a/internal/app/buildclient/client.go
+++ b/internal/app/buildclient/client.go
@@ -202,7 +202,7 @@ func (app *App) Run(ctx context.Context, arch string) error {
 	// send build request
 	bi, err := app.buildArtifact(ctx, def, arch, libraryRef)
 	if err != nil {
-		return fmt.Errorf("error building artifact: %w", err)
+		return err
 	}
 
 	if artifactFileName == "" {


### PR DESCRIPTION
Ensure `scs-build` returns a non-successful exit code on failure. 

Check `ImageSize` in `buildArtifact` to detect failed builds and return a suitable (though generic) error. Remove `errgroup` usage in `executeBuildCmd` to simplify logic, and ensure `err` is returned via Cobra.

```
$ go run ./cmd/scs-build build docker://sdfsdf 
Building for amd64...

...

failed to build amd64: failed to build image
exit status 1
```

Fixes #96 