### PR TITLE
fix: clean up output on error

### DIFF
--- a/cmd/scs-build/main.go
+++ b/cmd/scs-build/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	if err := execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/scs-build/root.go
+++ b/cmd/scs-build/root.go
@@ -15,8 +15,10 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "scs-build",
-	Short: "Sylabs Cloud Build Client",
+	Use:           "scs-build",
+	Short:         "Sylabs Cloud Build Client",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 // Build metadata set by linker.


### PR DESCRIPTION
Enable COBRA `SilenceErrors`/`SilenceUsage` to simplify output on error. Example:

```sh
$ go run ./cmd/scs-build/ build a b
Building for amd64...
Error: failed to build amd64: error reading def file a: open a: no such file or directory
exit status 1
```

Fixes #103 