### PR TITLE
Rename Sylabs Cloud to Singularity Container Services refs

### DIFF
--- a/README-DockerHub.md
+++ b/README-DockerHub.md
@@ -1,10 +1,10 @@
 # scs-build
 
-`scs-build` allows users to build [Singularity Image Format (SIF)](https://github.com/sylabs/sif) images via the [Sylabs Cloud](https://cloud.sylabs.io) or [Singularity Enterprise](https://sylabs.io/singularity-enterprise) without the need to install and configure Singularity.
+`scs-build` allows users to build [Singularity Image Format (SIF)](https://github.com/sylabs/sif) images via [Singularity Container Services](https://cloud.sylabs.io) or [Singularity Enterprise](https://sylabs.io/singularity-enterprise) without the need to install and configure Singularity.
 
 ## Usage
 
-Obtain an authentication token from [Sylabs Cloud](https://cloud.sylabs.io) or Singularity Enterprise installation, and export it in the environment:
+Obtain an access token from [Singularity Container Services](https://cloud.sylabs.io) or Singularity Enterprise installation, and export it in the environment:
 
 ```sh
 export SYLABS_AUTH_TOKEN=...
@@ -13,11 +13,11 @@ export SYLABS_AUTH_TOKEN=...
 To build an image, tag it and publish it directly to the Library:
 
 ```sh
-# Sylabs Cloud (cloud.sylabs.io)
+# Singularity Container Services (cloud.sylabs.io)
 docker run -e SYLABS_AUTH_TOKEN="${SYLABS_AUTH_TOKEN}" \
     sylabsio/scs-build build recipe.def library:<entity>/default/image:latest
 
-# Singularity Enterprise (replace cloud.enterprise.local with your installation)
+# Singularity Enterprise (replace "cloud.enterprise.local" with your installation host name)
 docker run -e SYLABS_AUTH_TOKEN="${SYLABS_AUTH_TOKEN}" \
     sylabsio/scs-build build recipe.def library://cloud.enterprise.local/<entity>/default/image:latest
 ```
@@ -25,12 +25,12 @@ docker run -e SYLABS_AUTH_TOKEN="${SYLABS_AUTH_TOKEN}" \
 To build an image and retrieve it:
 
 ```sh
-# Sylabs Cloud (cloud.sylabs.io)
+# Singularity Container Services (cloud.sylabs.io)
 docker run -e SYLABS_AUTH_TOKEN="${SYLABS_AUTH_TOKEN}" \
     -u $(id -u) -v `pwd`:/work \
     sylabsio/scs-build build /work/recipe.def /work/image.sif
 
-# Singularity Enterprise (replace cloud.enterprise.local with your installation)
+# Singularity Enterprise (replace "cloud.enterprise.local" with your installation host name)
 docker run -e SYLABS_AUTH_TOKEN="${SYLABS_AUTH_TOKEN}" \
     -u $(id -u) -v `pwd`:/work \
     sylabsio/scs-build build --url https://cloud.enterprise.local /work/recipe.def /work/image.sif
@@ -40,7 +40,7 @@ docker run -e SYLABS_AUTH_TOKEN="${SYLABS_AUTH_TOKEN}" \
 
 ### GitHub Actions
 
-Be sure to create a secret named `SYLABS_AUTH_TOKEN` containing token obtained from "Access Tokens" in [Sylabs Cloud](https://cloud.sylabs.io).
+Create a secret named `SYLABS_AUTH_TOKEN` containing access token obtained from "Access Tokens" in [Singularity Container Services](https://cloud.sylabs.io).
 
 See [examples/github-actions-ci.yaml](https://github.com/sylabs/scs-build-client/blob/main/examples/github-actions-ci.yaml) for an example configuration.
 
@@ -48,4 +48,4 @@ See [examples/github-actions-ci.yaml](https://github.com/sylabs/scs-build-client
 
 Example [gitlab-ci.yml](https://github.com/sylabs/scs-build-client/blob/main/examples/gitlab-ci.yml) is configured to build using file `alpine.def` contained within the project directory.
 
-This example configuration will store the build artifact (in this case, `artifact.sif`) within GitLab. Using a library reference (ie. `library:myuser/myproject/image`) will result in the build artifact automatically being pushed to [Sylabs Cloud](https://cloud.sylabs.io) or a local Singularity Enterprise installation.
+This example configuration will store the build artifact (in this case, `artifact.sif`) within GitLab. Using a library reference (ie. `library:myuser/myproject/image`) will result in the build artifact automatically being pushed to [Singularity Container Services](https://cloud.sylabs.io) or a local Singularity Enterprise installation.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# SCS Build Client
+# scs-build
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/sylabs/scs-build-client)](https://pkg.go.dev/github.com/sylabs/scs-build-client/client)
 [![Build Status](https://circleci.com/gh/sylabs/scs-build-client.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/scs-build-client)
 [![Code Coverage](https://codecov.io/gh/sylabs/scs-build-client/branch/main/graph/badge.svg)](https://codecov.io/gh/sylabs/scs-build-client)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/scs-build-client)](https://goreportcard.com/report/github.com/sylabs/scs-build-client)
 
-The SCS Build Client allows users to build [Singularity Image Format (SIF)](https://github.com/sylabs/sif) images via the [Sylabs Cloud](https://cloud.sylabs.io) or [Singularity Enterprise](https://sylabs.io/singularity-enterprise) without the need to install and configure Singularity.
+`scs-build` allows users to build [Singularity Image Format (SIF)](https://github.com/sylabs/sif) images via [Singularity Container Services](https://cloud.sylabs.io) or [Singularity Enterprise](https://sylabs.io/singularity-enterprise) without the need to install and configure Singularity.
 
 The repository also contains the [`github.com/sylabs/scs-build-client/client`](https://pkg.go.dev/github.com/sylabs/scs-build-client/client) Go module, which can be used to integrate support into other applications.
 
@@ -13,7 +13,7 @@ The repository also contains the [`github.com/sylabs/scs-build-client/client`](h
 
 `scs-build` is available in DockerHub ([sylabsio/scs-build](https://hub.docker.com/r/sylabsio/scs-build)) and standalone binaries are also published with [each release](https://github.com/sylabs/scs-build-client/releases).
 
-Obtain an authentication token from [Sylabs Cloud](https://cloud.sylabs.io) or Singularity Enterprise installation, and export it in the environment:
+Obtain an access token from [Singularity Container Services](https://cloud.sylabs.io) or Singularity Enterprise installation, and export it in the environment:
 
 ```sh
 export SYLABS_AUTH_TOKEN=...
@@ -22,20 +22,20 @@ export SYLABS_AUTH_TOKEN=...
 To build an image and retrieve it:
 
 ```sh
-# Sylabs Cloud (cloud.sylabs.io)
+# Singularity Container Services (cloud.sylabs.io)
 scs-build build recipe.def image.sif
 
-# Singularity Enterprise (replace cloud.enterprise.local with your installation)
+# Singularity Enterprise (replace "cloud.enterprise.local" with your installation host name)
 scs-build build --url https://cloud.enterprise.local recipe.def image.sif
 ```
 
 To build an image, tag it and publish it directly to the Library:
 
 ```sh
-# Sylabs Cloud (cloud.sylabs.io)
+# Singularity Container Services (cloud.sylabs.io)
 scs-build build recipe.def library:<entity>/default/image:latest
 
-# Singularity Enterprise (replace cloud.enterprise.local with your installation)
+# Singularity Enterprise (replace "cloud.enterprise.local" with your installation host name)
 scs-build build recipe.def library://cloud.enterprise.local/<entity>/default/image:latest
 ```
 
@@ -45,7 +45,7 @@ Be sure to substitute `<entity>` appropriately (generally your username.)
 
 ### GitHub Actions
 
-Be sure to create a secret named `SYLABS_AUTH_TOKEN` containing token obtained from "Access Tokens" in [Sylabs Cloud](https://cloud.sylabs.io).
+Create a secret named `SYLABS_AUTH_TOKEN` containing access token obtained from "Access Tokens" in [Singularity Container Services](https://cloud.sylabs.io).
 
 See [examples/github-actions-ci.yaml](examples/github-actions-ci.yaml) for an example configuration.
 
@@ -53,7 +53,7 @@ See [examples/github-actions-ci.yaml](examples/github-actions-ci.yaml) for an ex
 
 Example [gitlab-ci.yml](examples/gitlab-ci.yml) is configured to build using file `alpine.def` contained within the project directory.
 
-This example configuration will store the build artifact (in this case, `artifact.sif`) within GitLab. Using a library reference (ie. `library:myuser/myproject/image`) will result in the build artifact automatically being pushed to [Sylabs Cloud](https://cloud.sylabs.io) or a local Singularity Enterprise installation.
+This example configuration will store the build artifact (in this case, `artifact.sif`) within GitLab. Using a library reference (ie. `library:myuser/myproject/image`) will result in the build artifact automatically being pushed to [Singularity Container Services](https://cloud.sylabs.io) or a local Singularity Enterprise installation.
 
 ## Go Version Compatibility
 

--- a/cmd/scs-build/build.go
+++ b/cmd/scs-build/build.go
@@ -29,7 +29,7 @@ const (
 
 var buildCmd = &cobra.Command{
 	Use:   "build [flags] <build spec> <image path>",
-	Short: "Perform remote build on Sylabs Cloud (https://cloud.sylabs.io) or Singularity Enterprise",
+	Short: "Perform remote build on Singularity Container Services (https://cloud.sylabs.io) or Singularity Enterprise",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  executeBuildCmd,
 	Example: `
@@ -60,7 +60,7 @@ func addBuildCommand(rootCmd *cobra.Command) {
 	buildCmd.Flags().String(keyAccessToken, "", "Access token")
 	buildCmd.Flags().Bool(keySkipTLSVerify, false, "Skip SSL/TLS certificate verification")
 	buildCmd.Flags().StringSlice(keyArch, []string{runtime.GOARCH}, "Requested build architecture")
-	buildCmd.Flags().String(keyFrontendURL, "", "Sylabs Cloud or Singularity Enterprise URL")
+	buildCmd.Flags().String(keyFrontendURL, "", "Singularity Container Services or Singularity Enterprise URL")
 	buildCmd.Flags().Bool(keyForceOverwrite, false, "Overwrite image file if it exists")
 	rootCmd.AddCommand(buildCmd)
 }

--- a/cmd/scs-build/root.go
+++ b/cmd/scs-build/root.go
@@ -16,7 +16,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:           "scs-build",
-	Short:         "Sylabs Cloud Build Client",
+	Short:         "Singularity Container Services Build Client",
 	SilenceErrors: true,
 	SilenceUsage:  true,
 }


### PR DESCRIPTION
Rename "Sylabs Cloud" to "Singularity Container Services"