### PR TITLE
Use separate http clients for build & build context

### DIFF
--- a/client/build_context.go
+++ b/client/build_context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -70,7 +70,7 @@ func (c *Client) getBuildContextUploadLocation(ctx context.Context, size int64, 
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.buildContextHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
@@ -99,7 +99,7 @@ func (c *Client) putBuildContext(ctx context.Context, loc *url.URL, r io.Reader,
 
 	req.ContentLength = size
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.buildContextHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
@@ -226,7 +226,7 @@ func (c *Client) DeleteBuildContext(ctx context.Context, digest string, opts ...
 		return fmt.Errorf("%w", err)
 	}
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.buildContextHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}

--- a/internal/app/buildclient/client.go
+++ b/internal/app/buildclient/client.go
@@ -105,14 +105,15 @@ func New(ctx context.Context, cfg *Config) (*App, error) {
 	}
 	app.buildURL = feCfg.BuildAPI.URI
 
-	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr, _ := http.DefaultTransport.(*http.Transport)
+	tr = tr.Clone()
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: cfg.SkipTLSVerify}
 
 	app.buildClient, err = build.NewClient(
 		build.OptBaseURL(feCfg.BuildAPI.URI),
 		build.OptBearerToken(cfg.AuthToken),
 		build.OptUserAgent(cfg.UserAgent),
-		build.OptHTTPClient(&http.Client{Transport: tr}),
+		build.OptHTTPTransport(tr),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing build client: %w", err)


### PR DESCRIPTION
Uploading of build context has different network socket timeout requirements than regular build service requests. Use default timeout (`30s`) as taken from Singularity for all build service requests, and do not impose a timeout for build context uploads.

This PR removes the `OptHTTPClient()` functional argument and replaces it with `OptHTTPTransport()` to allow specifying a custom transport (ie. one with TLS configuration set). The same transport is used to construct the `http.Client` instances used for the build service operations.