### PR TITLE
More CI updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   cosign-version:
     type: string
-    default: '2.4.2'
+    default: '2.5.0'
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: node:22-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.63
+      - image: golangci/golangci-lint:v2.0.2
   golang-previous:
     docker:
       - image: golang:1.23

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: node:22-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v2.0.2
+      - image: golangci/golangci-lint:v2.1
   golang-previous:
     docker:
       - image: golang:1.23

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - unparam
     - unused
     - usetesting
+    - wsl
   exclusions:
     generated: lax
     presets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     - dupl
@@ -19,6 +20,7 @@ linters:
     - govet
     - grouper
     - ineffassign
+    - intrange
     - ireturn
     - maintidx
     - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bidichk
     - bodyclose
@@ -14,10 +15,7 @@ linters:
     - goconst
     - gocyclo
     - godox
-    - gofumpt
-    - goimports
     - goprintffuncname
-    - gosimple
     - govet
     - grouper
     - ineffassign
@@ -29,9 +27,28 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usetesting
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/client/archive.go
+++ b/client/archive.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -39,6 +39,7 @@ func (ar *archiver) writeEntry(name string) (err error) {
 	if _, ok := ar.archived[name]; ok {
 		return nil
 	}
+
 	defer func() {
 		if err == nil {
 			ar.archived[name] = struct{}{}
@@ -56,6 +57,7 @@ func (ar *archiver) writeEntry(name string) (err error) {
 	if err != nil {
 		return err
 	}
+
 	h.Name = filepath.ToSlash(name)
 
 	// Check that we're writing a supported type, and make any necessary adjustments.

--- a/client/build.go
+++ b/client/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -95,6 +95,7 @@ func OptBuildWorkingDirectory(dir string) BuildOption {
 		}
 
 		bo.workingDir = dir
+
 		return nil
 	}
 }
@@ -174,12 +175,14 @@ func (c *Client) Submit(ctx context.Context, definition io.Reader, opts ...Build
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
+
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 { // non-2xx status code

--- a/client/build_context.go
+++ b/client/build_context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -68,12 +68,14 @@ func (c *Client) getBuildContextUploadLocation(ctx context.Context, size int64, 
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.buildContextHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
+
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 { // non-2xx status code
@@ -94,6 +96,7 @@ func (c *Client) putBuildContext(ctx context.Context, loc *url.URL, r io.Reader,
 	if err != nil {
 		return err
 	}
+
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Del("Authorization")
 
@@ -103,11 +106,13 @@ func (c *Client) putBuildContext(ctx context.Context, loc *url.URL, r io.Reader,
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
+
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
 		return fmt.Errorf("%w", errorFromResponse(res))
 	}
+
 	return nil
 }
 
@@ -139,6 +144,7 @@ func (c *Client) uploadBuildContext(ctx context.Context, rw io.ReadWriteSeeker, 
 		if errors.Is(err, errContextAlreadyPresent) {
 			return digest, nil
 		}
+
 		return "", fmt.Errorf("failed to get build context upload location: %w", err)
 	}
 

--- a/client/build_context_test.go
+++ b/client/build_context_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/client/build_context_test.go
+++ b/client/build_context_test.go
@@ -253,8 +253,6 @@ func TestClient_DeleteBuildContext(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/client/build_context_test.go
+++ b/client/build_context_test.go
@@ -51,6 +51,7 @@ func (m *mockUploadBuildContext) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			Size   int64  `json:"size"`
 			Digest string `json:"digest"`
 		}
+
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			m.t.Fatalf("failed to decode request: %v", err)
 		}
@@ -218,6 +219,7 @@ func (m *mockDeleteBuildContext) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		if err := jsonresp.WriteError(w, "", m.code); err != nil {
 			m.t.Fatalf("failed to write error: %v", err)
 		}
+
 		return
 	}
 

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -36,6 +36,7 @@ func TestSubmit(t *testing.T) {
 
 	// Start a mock server
 	m := mockService{t: t}
+
 	s := httptest.NewServer(&m)
 	defer s.Close()
 
@@ -62,9 +63,11 @@ func TestSubmit(t *testing.T) {
 				if bi.ID() == "" {
 					t.Fatalf("invalid ID")
 				}
+
 				if bi.LibraryRef() == "" {
 					t.Errorf("empty Library ref")
 				}
+
 				if bi.LibraryURL() == "" {
 					t.Errorf("empty Library URL")
 				}
@@ -76,6 +79,7 @@ func TestSubmit(t *testing.T) {
 func TestCancel(t *testing.T) {
 	// Start a mock server
 	m := mockService{t: t}
+
 	s := httptest.NewServer(&m)
 	defer s.Close()
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -126,6 +126,7 @@ func NewClient(opts ...Option) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
+
 	c.baseURL = u
 
 	return &c, nil
@@ -153,6 +154,7 @@ func (c *Client) setRequestHeaders(h http.Header) {
 	if v := c.bearerToken; v != "" {
 		h.Set("Authorization", fmt.Sprintf("BEARER %s", v))
 	}
+
 	if v := c.userAgent; v != "" {
 		h.Set("User-Agent", v)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -153,6 +153,7 @@ func TestNewRequest(t *testing.T) {
 				if err != nil {
 					t.Errorf("failed to read body: %v", err)
 				}
+
 				if got, want := string(b), tt.body; got != want {
 					t.Errorf("got body %v, want %v", got, want)
 				}
@@ -161,10 +162,12 @@ func TestNewRequest(t *testing.T) {
 				if got, want := ok, (tt.wantBearerToken != ""); got != want {
 					t.Fatalf("presence of auth bearer %v, want %v", got, want)
 				}
+
 				if ok {
 					if got, want := len(authBearer), 1; got != want {
 						t.Fatalf("got %v auth bearer(s), want %v", got, want)
 					}
+
 					if got, want := authBearer[0], tt.wantBearerToken; got != want {
 						t.Errorf("got auth bearer %v, want %v", got, want)
 					}
@@ -174,10 +177,12 @@ func TestNewRequest(t *testing.T) {
 				if got, want := ok, (tt.wantUserAgent != ""); got != want {
 					t.Fatalf("presence of user agent %v, want %v", got, want)
 				}
+
 				if ok {
 					if got, want := len(userAgent), 1; got != want {
 						t.Fatalf("got %v user agent(s), want %v", got, want)
 					}
+
 					if got, want := userAgent[0], tt.wantUserAgent; got != want {
 						t.Errorf("got user agent %v, want %v", got, want)
 					}

--- a/client/error.go
+++ b/client/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -27,6 +27,7 @@ func (e *httpError) Error() string {
 	if e.err != nil {
 		return fmt.Sprintf("%v %v: %v", e.Code, http.StatusText(e.Code), e.err.Error())
 	}
+
 	return fmt.Sprintf("%v %v", e.Code, http.StatusText(e.Code))
 }
 

--- a/client/error_test.go
+++ b/client/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -41,9 +41,11 @@ func TestHTTPError(t *testing.T) {
 			if got, want := err.Code, tt.code; got != want {
 				t.Errorf("got code %v, want %v", got, want)
 			}
+
 			if got, want := err.Unwrap(), tt.err; got != want {
 				t.Errorf("got unwrapped error %v, want %v", got, want)
 			}
+
 			if got, want := err.Error(), tt.wantMessage; got != want {
 				t.Errorf("got message %v, want %v", got, want)
 			}

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -170,7 +170,6 @@ func TestBuild(t *testing.T) {
 	m.httpAddr = s.Listener.Addr().String()
 
 	// Table of tests to run
-	// nolint:maligned
 	tests := []struct {
 		description         string
 		expectSubmitSuccess bool

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -52,6 +52,7 @@ func newResponse(m *mockService, id string, libraryRef string) rawBuildInfo {
 		Scheme: "http",
 		Host:   m.httpAddr,
 	}
+
 	if libraryRef == "" {
 		libraryRef = "library://user/collection/image"
 	}
@@ -72,9 +73,11 @@ func (m *mockService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var br struct {
 			LibraryRef string `json:"libraryRef"`
 		}
+
 		if err := json.NewDecoder(r.Body).Decode(&br); err != nil {
 			m.t.Fatalf("failed to parse request: %v", err)
 		}
+
 		if m.buildResponseCode == http.StatusCreated {
 			id := newObjectID()
 			if err := jsonresp.WriteResponse(w, newResponse(m, id, br.LibraryRef), m.buildResponseCode); err != nil {
@@ -91,6 +94,7 @@ func (m *mockService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if id == "" {
 			m.t.Fatalf("failed to parse ID '%v'", id)
 		}
+
 		if m.statusResponseCode == http.StatusOK {
 			if err := jsonresp.WriteResponse(w, newResponse(m, id, ""), m.statusResponseCode); err != nil {
 				m.t.Fatal(err)
@@ -139,6 +143,7 @@ func (m *mockService) ServeWebsocket(w http.ResponseWriter, r *http.Request) {
 		if err = ws.WriteMessage(websocket.TextMessage, []byte(stdoutContents)); err != nil {
 			m.t.Fatalf("error writing websocket message - %v", err)
 		}
+
 		if err = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(m.wsCloseCode, "")); err != nil {
 			m.t.Fatalf("error writing websocket close message - %v", err)
 		}
@@ -155,14 +160,18 @@ func TestBuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
+
 	f.Close()
+
 	defer os.Remove(f.Name())
 
 	// Start a mock server
 	m := mockService{t: t}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", m.ServeHTTP)
 	mux.HandleFunc(wsPath, m.ServeWebsocket)
+
 	s := httptest.NewServer(mux)
 	defer s.Close()
 
@@ -221,6 +230,7 @@ func TestBuild(t *testing.T) {
 				if err == nil {
 					t.Fatalf("unexpected submit success")
 				}
+
 				return
 			}
 			// Ensure the handler returned no error, and the response is as expected
@@ -232,7 +242,9 @@ func TestBuild(t *testing.T) {
 				fully: true,
 				err:   nil,
 			}
+
 			err = c.GetOutput(tt.ctx, bd.ID(), tor)
+
 			if tt.expectStreamSuccess {
 				// Ensure the handler returned no error, and the response is as expected
 				if err != nil {

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/client/object_id_test.go
+++ b/client/object_id_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -25,29 +25,36 @@ var (
 
 func readRandomUint32() uint32 {
 	var b [4]byte
-	_, err := io.ReadFull(rand.Reader, b[:])
-	if err != nil {
+
+	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
 		panic(fmt.Errorf("cannot read random object id: %v", err))
 	}
+
 	return ((uint32(b[0]) << 0) | (uint32(b[1]) << 8) | (uint32(b[2]) << 16) | (uint32(b[3]) << 24))
 }
 
 func readMachineID() []byte {
 	var sum [3]byte
+
 	id := sum[:]
+
 	hostname, err1 := os.Hostname()
 	if err1 != nil {
 		_, err2 := io.ReadFull(rand.Reader, id)
 		if err2 != nil {
 			panic(fmt.Errorf("cannot get hostname: %v; %v", err1, err2))
 		}
+
 		return id
 	}
+
 	hw := md5.New()
 	if _, err := hw.Write([]byte(hostname)); err != nil {
 		panic(err)
 	}
+
 	copy(id, hw.Sum(nil))
+
 	return id
 }
 
@@ -67,5 +74,6 @@ func newObjectID() string {
 	b[9] = byte(i >> 16)
 	b[10] = byte(i >> 8)
 	b[11] = byte(i)
+
 	return hex.EncodeToString(b[:])
 }

--- a/client/output.go
+++ b/client/output.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -28,6 +28,7 @@ func (c *Client) GetOutput(ctx context.Context, buildID string, w io.Writer) err
 	if c.baseURL.Scheme == "https" {
 		wsScheme = "wss"
 	}
+
 	u.Scheme = wsScheme
 
 	h := http.Header{}
@@ -50,8 +51,11 @@ func (c *Client) GetOutput(ctx context.Context, buildID string, w io.Writer) err
 	if err != nil {
 		return fmt.Errorf("failed to dial: %w", err)
 	}
-	defer resp.Body.Close()
-	defer ws.Close()
+
+	defer func() {
+		resp.Body.Close()
+		ws.Close()
+	}()
 
 	errChan := make(chan error)
 
@@ -88,6 +92,7 @@ func (c *Client) GetOutput(ctx context.Context, buildID string, w io.Writer) err
 		ws.Close()
 
 		<-errChan
+
 		return nil
 	case err := <-errChan:
 		return err

--- a/client/output_test.go
+++ b/client/output_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/client/output_test.go
+++ b/client/output_test.go
@@ -53,8 +53,6 @@ func TestOutput(t *testing.T) {
 
 	// Loop over test cases
 	for _, useTLS := range []bool{true, false} {
-		useTLS := useTLS
-
 		name := func() string {
 			if useTLS {
 				return "WithTLS"
@@ -66,8 +64,6 @@ func TestOutput(t *testing.T) {
 			t.Parallel()
 
 			for _, tt := range tests {
-				tt := tt
-
 				t.Run(tt.description, func(t *testing.T) {
 					// Start a mock server
 					m := mockService{t: t}

--- a/client/output_test.go
+++ b/client/output_test.go
@@ -34,7 +34,6 @@ func TestOutput(t *testing.T) {
 	defer cancel()
 
 	// Table of tests to run
-	// nolint:maligned
 	tests := []struct {
 		description     string
 		expectSuccess   bool

--- a/client/output_test.go
+++ b/client/output_test.go
@@ -25,6 +25,7 @@ func (tor testOutputWriter) Write(p []byte) (int, error) {
 	if tor.fully {
 		return len(p), tor.err
 	}
+
 	return len(p) - 1, tor.err
 }
 
@@ -57,6 +58,7 @@ func TestOutput(t *testing.T) {
 			if useTLS {
 				return "WithTLS"
 			}
+
 			return "WithoutTLS"
 		}()
 
@@ -73,6 +75,7 @@ func TestOutput(t *testing.T) {
 					clientOptions := []Option{}
 
 					var s *httptest.Server
+
 					if useTLS {
 						s = httptest.NewTLSServer(mux)
 
@@ -80,12 +83,14 @@ func TestOutput(t *testing.T) {
 						if !ok {
 							t.Fatal("Internal error- unable to typecast HTTP client transport")
 						}
+
 						tr = tr.Clone()
 
 						clientOptions = append(clientOptions, OptHTTPTransport(tr))
 					} else {
 						s = httptest.NewServer(mux)
 					}
+
 					defer s.Close()
 
 					// Mock server address is fixed for all tests
@@ -104,7 +109,9 @@ func TestOutput(t *testing.T) {
 						fully: tt.outputReadFully,
 						err:   tt.outputReadErr,
 					}
+
 					err = c.GetOutput(tt.ctx, "id", tor)
+
 					if tt.expectSuccess {
 						// Ensure the handler returned no error, and the response is as expected
 						if err != nil {

--- a/client/status_test.go
+++ b/client/status_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -33,6 +33,7 @@ func TestStatus(t *testing.T) {
 
 	// Start a mock server
 	m := mockService{t: t}
+
 	s := httptest.NewServer(&m)
 	defer s.Close()
 
@@ -60,9 +61,11 @@ func TestStatus(t *testing.T) {
 				if bi.ID() != id {
 					t.Errorf("mismatched ID: %v/%v", bi.ID(), id)
 				}
+
 				if bi.LibraryRef() == "" {
 					t.Errorf("empty Library ref")
 				}
+
 				if bi.LibraryURL() == "" {
 					t.Errorf("empty Library URL")
 				}

--- a/client/version.go
+++ b/client/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -42,5 +42,6 @@ func (c *Client) GetVersion(ctx context.Context) (string, error) {
 	if err := jsonresp.ReadResponse(res.Body, &vi); err != nil {
 		return "", fmt.Errorf("%w", err)
 	}
+
 	return vi.Version, nil
 }

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -96,7 +96,6 @@ func TestClient_GetVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -27,6 +27,7 @@ func (m *mockVersion) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err := jsonresp.WriteError(w, m.message, m.code); err != nil {
 			m.t.Fatalf("failed to write error: %v", err)
 		}
+
 		return
 	}
 

--- a/client/version_test.go
+++ b/client/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.

--- a/internal/app/buildclient/artifact.go
+++ b/internal/app/buildclient/artifact.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -32,9 +32,11 @@ func (app *App) buildArtifact(ctx context.Context, arch string, def []byte, buil
 	if err != nil {
 		return nil, fmt.Errorf("error submitting remote build: %w", err)
 	}
+
 	if err := app.buildClient.GetOutput(ctx, bi.ID(), os.Stdout); err != nil {
 		return nil, fmt.Errorf("error streaming remote build output: %w", err)
 	}
+
 	if bi, err = app.buildClient.GetStatus(ctx, bi.ID()); err != nil {
 		return nil, fmt.Errorf("error getting remote build status: %w", err)
 	}
@@ -53,6 +55,7 @@ func (app *App) retrieveArtifact(ctx context.Context, bi *build.BuildInfo, filen
 	if err != nil {
 		return fmt.Errorf("error opening file %s for writing: %w", filename, err)
 	}
+
 	defer func() {
 		_ = fp.Close()
 	}()
@@ -72,7 +75,8 @@ func (app *App) retrieveArtifact(ctx context.Context, bi *build.BuildInfo, filen
 		if strings.ToLower(values[0]) == "sha256" {
 			imageChecksum := hex.EncodeToString(h.Sum(nil))
 			if values[1] != imageChecksum {
-				fmt.Fprintf(os.Stderr, "Error: image checksum mismatch (expecting %v, got %v)\n", values[1], imageChecksum)
+				fmt.Fprintf(os.Stderr, "Error: image checksum mismatch (expecting %v, got %v)\n",
+					values[1], imageChecksum)
 			} else {
 				fmt.Fprintf(os.Stderr, "Image checksum verified successfully.\n")
 			}

--- a/internal/app/buildclient/build.go
+++ b/internal/app/buildclient/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/app/buildclient/build.go
+++ b/internal/app/buildclient/build.go
@@ -103,9 +103,11 @@ func AddBuildCommand(rootCmd *cobra.Command) {
 
 func getConfig(cmd *cobra.Command) (*viper.Viper, error) {
 	v := viper.New()
+
 	v.SetEnvPrefix("sylabs")
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
 	return v, v.BindPFlags(cmd.Flags())
 }
 
@@ -137,6 +139,7 @@ func executeBuildCmd(cmd *cobra.Command, args []string) error {
 		v.GetBool(keySign)
 
 	var signerOpts []integrity.SignerOpt
+
 	if signing {
 		fmt.Printf("Build artifacts will be automatically signed\n")
 
@@ -147,6 +150,7 @@ func executeBuildCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	var libraryRef string
+
 	if len(args) > 1 {
 		libraryRef = args[1]
 	} else {

--- a/internal/app/buildclient/build.go
+++ b/internal/app/buildclient/build.go
@@ -108,7 +108,9 @@ func executeBuildCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error getting config: %w", err)
 	}
 
-	if v.GetString(keyPassphrase) != "" && !(cmd.Flag(keySigningKeyIndex).Changed || cmd.Flag(keyFingerprint).Changed) {
+	if v.GetString(keyPassphrase) != "" &&
+		!cmd.Flag(keySigningKeyIndex).Changed &&
+		!cmd.Flag(keyFingerprint).Changed {
 		return fmt.Errorf("--passphrase only effective when PGP signing enabled")
 	}
 

--- a/internal/app/buildclient/build_test.go
+++ b/internal/app/buildclient/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/app/buildclient/build_test.go
+++ b/internal/app/buildclient/build_test.go
@@ -7,6 +7,9 @@ package buildclient
 
 import (
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func TestValidateBuildSpec(t *testing.T) {
@@ -29,6 +32,79 @@ func TestValidateBuildSpec(t *testing.T) {
 			_, err := parseBuildSpec(tt.buildSpec)
 			if (err != nil) != tt.expectError {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func withDefaults(t *testing.T) (*cobra.Command, *viper.Viper) {
+	t.Helper()
+
+	v := viper.New()
+
+	cmd := &cobra.Command{
+		Use: "testcmd",
+		Run: func(*cobra.Command, []string) {},
+	}
+
+	addBuildCommandFlags(cmd)
+
+	return cmd, v
+}
+
+func withUnrequiredPassphrase(t *testing.T) (*cobra.Command, *viper.Viper) {
+	t.Helper()
+
+	cmd, v := withDefaults(t)
+
+	v.Set(keyPassphrase, "passphrase goes here")
+
+	return cmd, v
+}
+
+func withKeyIdx(t *testing.T) (*cobra.Command, *viper.Viper) {
+	t.Helper()
+
+	cmd, v := withDefaults(t)
+
+	v.Set(keyPassphrase, "passphrase goes here")
+
+	v.Set(keySigningKeyIndex, 0)
+	cmd.Flag(keySigningKeyIndex).Changed = true
+
+	return cmd, v
+}
+
+func withFingerprint(t *testing.T) (*cobra.Command, *viper.Viper) {
+	t.Helper()
+
+	cmd, v := withDefaults(t)
+
+	v.Set(keyPassphrase, "passphrase goes here")
+
+	cmd.SetArgs([]string{"--fingerprint=xxx"})
+
+	cmd.Flag(keyFingerprint).Changed = true
+
+	return cmd, v
+}
+
+func TestValidateArgs(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		expectError error
+		setupFunc   func(t *testing.T) (*cobra.Command, *viper.Viper)
+	}{
+		{"Defaults", nil, withDefaults},
+		{"WithUnrequiredPassphrase", errPassphraseNotRequired, withUnrequiredPassphrase},
+		{"ValidKeyIdx", nil, withKeyIdx},
+		{"ValidFingerprint", nil, withFingerprint},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, v := tt.setupFunc(t)
+
+			if got, want := validateArgs(cmd, v), tt.expectError; got != want {
+				t.Fatalf("Unexpected error: got %v, want %v", got, want)
 			}
 		})
 	}

--- a/internal/app/buildclient/build_test.go
+++ b/internal/app/buildclient/build_test.go
@@ -68,6 +68,7 @@ func withKeyIdx(t *testing.T) (*cobra.Command, *viper.Viper) {
 	v.Set(keyPassphrase, "passphrase goes here")
 
 	v.Set(keySigningKeyIndex, 0)
+
 	cmd.Flag(keySigningKeyIndex).Changed = true
 
 	return cmd, v

--- a/internal/app/buildclient/build_test.go
+++ b/internal/app/buildclient/build_test.go
@@ -26,8 +26,6 @@ func TestValidateBuildSpec(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := parseBuildSpec(tt.buildSpec)
 			if (err != nil) != tt.expectError {

--- a/internal/app/buildclient/client_test.go
+++ b/internal/app/buildclient/client_test.go
@@ -223,7 +223,7 @@ func Test_build(t *testing.T) {
 		defer c.Close()
 
 		// Write 10 lines of sample build output
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			if err := c.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("Sample remote build output: line #%d\n", i))); err != nil {
 				t.Fatalf("error writing to websocket: %v", err)
 			}

--- a/internal/app/buildclient/client_test.go
+++ b/internal/app/buildclient/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/app/buildclient/client_test.go
+++ b/internal/app/buildclient/client_test.go
@@ -44,21 +44,21 @@ func newTestFEServer(t *testing.T) *httptest.Server {
 }
 
 func TestNew(t *testing.T) {
-	const dockerBuildSpec = "docker://alpine:3"
-	const localSIFFileName = "alpine_3.sif"
-	const defFile = "alpine.def"
+	const (
+		dockerBuildSpec  = "docker://alpine:3"
+		localSIFFileName = "alpine_3.sif"
+		defFile          = "alpine.def"
 
-	const libraryPath = "entity/collection/container"
-	const tag = "tag"
+		libraryPath = "entity/collection/container"
+		tag         = "tag"
+	)
 
 	testLibraryRef := fmt.Sprintf("library:///%v:%v", libraryPath, tag)
-	_ = testLibraryRef
 
 	testFeSrv := newTestFEServer(t)
 	defer testFeSrv.Close()
 
 	testLibraryRefWithHost := fmt.Sprintf("library://%v/%v:%v", defaultFEHost, libraryPath, tag)
-	_ = testLibraryRefWithHost
 
 	for _, tt := range []struct {
 		name        string
@@ -96,6 +96,7 @@ func TestNew(t *testing.T) {
 			if (err != nil) != tt.expectError {
 				t.Fatalf("Unexpected error: %v", err)
 			}
+
 			if err != nil {
 				// Received expected error.
 				return
@@ -104,6 +105,7 @@ func TestNew(t *testing.T) {
 			if tt.buildSpec == dockerBuildSpec {
 				assert.Equal(t, dockerBuildSpec, b.buildSpec)
 			}
+
 			if tt.libraryRef == localSIFFileName {
 				assert.Equal(t, localSIFFileName, b.dstFileName)
 				assert.Nil(t, b.libraryRef)
@@ -259,7 +261,6 @@ func Test_build(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initialization error: %v", err)
 	}
-	_ = app
 
 	const buildDef = "bootstrap: docker\nfrom: alpine:3\n"
 

--- a/internal/app/buildclient/files.go
+++ b/internal/app/buildclient/files.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -74,6 +74,7 @@ func (d definition) SourceFiles() (result []string) {
 			result = append(result, f.Src)
 		}
 	}
+
 	return
 }
 
@@ -104,20 +105,23 @@ func (app *App) parseDefinition(ctx context.Context, r io.Reader) (definition, e
 	}
 
 	var d definition
+
 	if err := jsonresp.ReadResponse(res.Body, &d); err != nil {
 		return definition{}, err
 	}
+
 	return d, err
 }
 
 // ExtractFiles makes request to remote build server to parse specified def file and returns
 // files referenced in '%files' section(s)
-func (app *App) getFiles(ctx context.Context, r io.Reader) (files []string, err error) {
+func (app *App) getFiles(ctx context.Context, r io.Reader) ([]string, error) {
 	d, err := app.parseDefinition(ctx, r)
 	if err != nil {
-		err = fmt.Errorf("def file parse error: %w", err)
-		return
+		return nil, fmt.Errorf("def file parse error: %w", err)
 	}
+
+	files := []string{}
 
 	for _, f := range d.BuildData.Files {
 		if f.Stage() != "" {
@@ -129,11 +133,12 @@ func (app *App) getFiles(ctx context.Context, r io.Reader) (files []string, err 
 			updFileName, err := ft.SourcePath()
 			if err != nil {
 				err = fmt.Errorf("error parsing def file: %w", err)
-				return []string{}, err
+				return nil, err
 			}
 
 			files = append(files, updFileName)
 		}
 	}
-	return
+
+	return files, nil
 }

--- a/internal/app/buildclient/files_test.go
+++ b/internal/app/buildclient/files_test.go
@@ -53,10 +53,12 @@ func Test_SourcePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ft := FileTransport{Src: tt.source}
+
 			got, err := ft.SourcePath()
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
+
 			log.Println(got)
 
 			if tt.source == "/" && got != "." {
@@ -69,20 +71,24 @@ func Test_SourcePath(t *testing.T) {
 func TestExtractFiles(t *testing.T) {
 	// Create test build server
 	r := http.NewServeMux()
+
 	r.HandleFunc("/v1/convert-def-file", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+
 		if _, err := w.Write(defFileData); err != nil {
 			t.Fatalf("HTTP write error: %v", err)
 		}
 	})
+
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
 	// Create test frontend server
 	feRouter := http.NewServeMux()
+
 	feRouter.HandleFunc("/assets/config/config.prod.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -92,6 +98,7 @@ func TestExtractFiles(t *testing.T) {
 			t.Fatalf("error writing HTTP response: %v", err)
 		}
 	})
+
 	tsFE := httptest.NewServer(feRouter)
 	defer tsFE.Close()
 

--- a/internal/app/buildclient/files_test.go
+++ b/internal/app/buildclient/files_test.go
@@ -31,8 +31,6 @@ func Test_Stage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			f := files{Args: tt.args}
 
@@ -53,8 +51,6 @@ func Test_SourcePath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			ft := FileTransport{Src: tt.source}
 			got, err := ft.SourcePath()

--- a/internal/app/buildclient/files_test.go
+++ b/internal/app/buildclient/files_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/internal/app/buildclient/sign.go
+++ b/internal/app/buildclient/sign.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2023-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,9 +15,9 @@ func sign(fileName string, opts ...integrity.SignerOpt) error {
 	if err != nil {
 		return err
 	}
+
 	defer func() {
-		err := f.UnloadContainer()
-		if err != nil {
+		if err := f.UnloadContainer(); err != nil {
 			return
 		}
 	}()
@@ -26,5 +26,6 @@ func sign(fileName string, opts ...integrity.SignerOpt) error {
 	if err != nil {
 		return err
 	}
+
 	return is.Sign()
 }

--- a/internal/app/buildclient/util.go
+++ b/internal/app/buildclient/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,6 +22,7 @@ func splitLibraryRef(libraryRef string) (string, string) {
 	if len(comps) < 2 {
 		return comps[0], ""
 	}
+
 	return comps[0], comps[1]
 }
 

--- a/internal/app/buildclient/util_test.go
+++ b/internal/app/buildclient/util_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -98,6 +98,7 @@ func Test_getBuildDef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var result string
+
 			if tt.useTempFile {
 				result = t.TempDir() + tt.fileName
 				if tt.fileName != "" {
@@ -105,10 +106,11 @@ func Test_getBuildDef(t *testing.T) {
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
-					_, err = fp.Write([]byte(tt.want))
-					if err != nil {
+
+					if _, err := fp.Write([]byte(tt.want)); err != nil {
 						t.Fatalf("%v", err)
 					}
+
 					defer fp.Close()
 				}
 			} else {

--- a/internal/pkg/endpoints/frontend_test.go
+++ b/internal/pkg/endpoints/frontend_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -78,6 +78,7 @@ func TestGetFrontendConfig(t *testing.T) {
 				assert.Equal(t, result.LibraryAPI.URI, tt.expectedLibraryURI)
 				assert.Equal(t, result.BuildAPI.URI, tt.expectedBuildURI)
 			}
+
 			if tt.expectedErr != nil {
 				assert.Nil(t, result)
 				assert.ErrorIs(t, err, tt.expectedErr)


### PR DESCRIPTION
- Bump `golangci-lint` to v2.1.x
- Resolve issues discovered by same (incl. implementing `build` subcommand argument validation unit tests)